### PR TITLE
Malformed HTTP request in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ int main(int argc, const char* argv[])
     tcs_connect_str(client_socket, "example.com", 80);
 
     uint8_t send_buffer[] = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-    tcs_send(client_socket, send_buffer, sizeof(send_buffer), TCS_MSG_SENDALL, NULL);
+    tcs_send(client_socket, send_buffer, sizeof(send_buffer) - 1, TCS_MSG_SENDALL, NULL);
 
     uint8_t recv_buffer[8192] = {0};
     size_t bytes_received = 0;

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ int main(int argc, const char* argv[])
     tcs_socket(&client_socket, TCS_AF_IP4, TCS_SOCK_STREAM, TCS_PROTOCOL_IP_TCP);
     tcs_connect_str(client_socket, "example.com", 80);
 
-    uint8_t send_buffer[] = "GET / HTTP/1.1\nHost: example.com\n\n";
+    uint8_t send_buffer[] = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     tcs_send(client_socket, send_buffer, sizeof(send_buffer), TCS_MSG_SENDALL, NULL);
 
     uint8_t recv_buffer[8192] = {0};

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Example from README")
     REQUIRE(tcs_socket(&client_socket, TCS_AF_IP4, TCS_SOCK_STREAM, TCS_PROTOCOL_IP_TCP) == TCS_SUCCESS);
     REQUIRE(tcs_connect_str(client_socket, "example.com", 80) == TCS_SUCCESS);
 
-    uint8_t send_buffer[] = "GET / HTTP/1.1\nHost: example.com\n\n";
+    uint8_t send_buffer[] = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     CHECK(tcs_send(client_socket, send_buffer, sizeof(send_buffer), TCS_MSG_SENDALL, NULL) == TCS_SUCCESS);
 
     static uint8_t recv_buffer[8192] = {0};

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Example from README")
     REQUIRE(tcs_connect_str(client_socket, "example.com", 80) == TCS_SUCCESS);
 
     uint8_t send_buffer[] = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-    CHECK(tcs_send(client_socket, send_buffer, sizeof(send_buffer), TCS_MSG_SENDALL, NULL) == TCS_SUCCESS);
+    CHECK(tcs_send(client_socket, send_buffer, sizeof(send_buffer) - 1, TCS_MSG_SENDALL, NULL) == TCS_SUCCESS);
 
     static uint8_t recv_buffer[8192] = {0};
     size_t bytes_received = 0;


### PR DESCRIPTION
The line ending should be CR LF (https://www.rfc-editor.org/rfc/rfc2616#section-2.2).
This is not a big deal, I think.

The bigger deal is the length of the message is off by one, which gave me errors.